### PR TITLE
incorporated cuTENSOR einsum sample (no more std::vector and std::uno…

### DIFF
--- a/3rdparty/mshadow/mshadow/stream_gpu-inl.h
+++ b/3rdparty/mshadow/mshadow/stream_gpu-inl.h
@@ -244,16 +244,16 @@ struct Stream<gpu> {
     cutensorStatus_t err = cutensorInit(&cutensor_handle_);
     CHECK_EQ(err, CUTENSOR_STATUS_SUCCESS) << cutensorGetErrorString(err);
 
-    constexpr int32_t numCachelines = 1024;
-    size_t sizeCache = numCachelines * sizeof(cutensorPlanCacheline_t);
-    cutensor_cachelines_ = (cutensorPlanCacheline_t*) malloc(sizeCache);
-
-    err = cutensorHandleAttachPlanCachelines(&cutensor_handle_, cutensor_cachelines_, numCachelines);
-    CHECK_EQ(err, CUTENSOR_STATUS_SUCCESS) << cutensorGetErrorString(err);
-
     const char* cacheFilename = getenv("MXNET_CUTENSOR_CACHEFILE");
     if (cacheFilename != nullptr)
     {
+        constexpr int32_t numCachelines = 1024;
+        size_t sizeCache = numCachelines * sizeof(cutensorPlanCacheline_t);
+        cutensor_cachelines_ = (cutensorPlanCacheline_t*) malloc(sizeCache);
+
+        err = cutensorHandleAttachPlanCachelines(&cutensor_handle_, cutensor_cachelines_, numCachelines);
+        CHECK_EQ(err, CUTENSOR_STATUS_SUCCESS) << cutensorGetErrorString(err);
+
         uint32_t numCachelinesRead = 0;
         cutensorStatus_t status = cutensorHandleReadCacheFromFile(&cutensor_handle_, cacheFilename, &numCachelinesRead);
         if (status == CUTENSOR_STATUS_IO_ERROR)

--- a/3rdparty/mshadow/mshadow/stream_gpu-inl.h
+++ b/3rdparty/mshadow/mshadow/stream_gpu-inl.h
@@ -274,11 +274,11 @@ struct Stream<gpu> {
 template<>
 inline void DeleteStream<gpu>(Stream<gpu> *stream) {
   if (stream) {
+    stream->DestroyCuTensorHandle();
     MSHADOW_CUDA_CALL(cudaStreamDestroy(stream->stream_));
     stream->DestroyBlasHandle();
     stream->DestroySolverHandle();
     stream->DestroyDnnHandle();
-    stream->DestroyCuTensorHandle();
     delete stream;
   }
 }

--- a/3rdparty/mshadow/mshadow/stream_gpu-inl.h
+++ b/3rdparty/mshadow/mshadow/stream_gpu-inl.h
@@ -65,6 +65,7 @@ struct Stream<gpu> {
   HandleState dnn_handle_ownership_;
   /*! \brief cutensor handle ownership */
   HandleState cutensor_handle_ownership_;
+  cutensorPlanCacheline_t* cutensor_cachelines_ = nullptr;
   /*! \brief cudaDeviceProp */
   cudaDeviceProp prop;
   /*! \brief dev id */
@@ -80,7 +81,8 @@ struct Stream<gpu> {
       , blas_handle_ownership_(NoHandle)
       , solver_handle_ownership_(NoHandle)
       , dnn_handle_ownership_(NoHandle)
-      , cutensor_handle_ownership_(NoHandle) {}
+      , cutensor_handle_ownership_(NoHandle)
+      , cutensor_cachelines_(nullptr){}
   /*!
    * \brief wait for all the computation associated
    *  with this stream to complete
@@ -218,6 +220,21 @@ struct Stream<gpu> {
 #if MSHADOW_USE_CUTENSOR == 1
     if (cutensor_handle_ownership_ == OwnHandle) {
       // not destroy method available
+      if (cutensor_cachelines_ != nullptr)
+      {
+          cutensorStatus_t err;
+          const char* cacheFilename = getenv("MXNET_CUTENSOR_CACHEFILE");
+          if (cacheFilename != nullptr)
+          {
+              err = cutensorHandleWriteCacheToFile(&cutensor_handle_, cacheFilename);
+              CHECK_EQ(err, CUTENSOR_STATUS_SUCCESS) << cutensorGetErrorString(err);
+          }
+          err = cutensorHandleDetachPlanCachelines(&cutensor_handle_);
+          CHECK_EQ(err, CUTENSOR_STATUS_SUCCESS) << cutensorGetErrorString(err);
+          free(cutensor_cachelines_);
+          cutensor_cachelines_ = nullptr;
+      }
+      this->cutensor_handle_ownership_ = NoHandle;
     }
 #endif
   }
@@ -226,6 +243,29 @@ struct Stream<gpu> {
     //this->DestroyCuTensorHandle();
     cutensorStatus_t err = cutensorInit(&cutensor_handle_);
     CHECK_EQ(err, CUTENSOR_STATUS_SUCCESS) << cutensorGetErrorString(err);
+
+    constexpr int32_t numCachelines = 1024;
+    size_t sizeCache = numCachelines * sizeof(cutensorPlanCacheline_t);
+    cutensor_cachelines_ = (cutensorPlanCacheline_t*) malloc(sizeCache);
+
+    err = cutensorHandleAttachPlanCachelines(&cutensor_handle_, cutensor_cachelines_, numCachelines);
+    CHECK_EQ(err, CUTENSOR_STATUS_SUCCESS) << cutensorGetErrorString(err);
+
+    const char* cacheFilename = getenv("MXNET_CUTENSOR_CACHEFILE");
+    if (cacheFilename != nullptr)
+    {
+        uint32_t numCachelinesRead = 0;
+        cutensorStatus_t status = cutensorHandleReadCacheFromFile(&cutensor_handle_, cacheFilename, &numCachelinesRead);
+        if (status == CUTENSOR_STATUS_IO_ERROR)
+        {
+            printf("File (%s) doesn't seem to exist.\n", cacheFilename);
+        }
+        else if (status == CUTENSOR_STATUS_INSUFFICIENT_WORKSPACE)
+        {
+            printf("Cannot read cache: Please attach at least %d cachelines to the handle.\n", numCachelinesRead);
+        }
+    }
+
     // At this point, we have the resource which may need to be freed
     this->cutensor_handle_ownership_ = OwnHandle;
 #endif
@@ -238,6 +278,7 @@ inline void DeleteStream<gpu>(Stream<gpu> *stream) {
     stream->DestroyBlasHandle();
     stream->DestroySolverHandle();
     stream->DestroyDnnHandle();
+    stream->DestroyCuTensorHandle();
     delete stream;
   }
 }


### PR DESCRIPTION
…rdered_map)

TODO: we could use this sample to support einsum's implicit mode as well

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
